### PR TITLE
feat: Fix niceit

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -13,7 +13,7 @@ set -o histexpand
 # Useful if it's deseriable for long running tasks to mimimally
 # impact other application/services that maybe running.
 niceit() {
-	ionice -c 3 nice -n 19 $@
+	ionice -c 3 nice -n 19 "$@"
 }
 export -f niceit
 


### PR DESCRIPTION
Added quotes to $@ so we properly handle parameters with quoted spaces. Before this fix this journalctl command fails:

  $ niceit journalctl -u eth1.service --since="2023-02-18 00:00:13"
  Failed to add match '00:00:13': Invalid argument

But adding the quotes it works:

  $ niceit journalctl -u eth1.service --since="2023-02-18 00:10"
  Feb 18 00:10:03 hazel geth[10953]: INFO [02-18|00:10:03.412] Imported ..,